### PR TITLE
Fixes for macOS / Xcode build

### DIFF
--- a/src/ga/graph/components/paragraph_component.h
+++ b/src/ga/graph/components/paragraph_component.h
@@ -157,7 +157,7 @@ protected:
 		}
 	}
 
-	StyledText Paragraph::parseMarkdownStyles( const std::string& text );
+	StyledText parseMarkdownStyles( const std::string& text );
 
 	std::string m_text;       // raw text, could contain **bold** and *italics*
 	StyledText m_styledText;  // styled text, parsed for **bold** and *italics*

--- a/src/ga/graph/scene.h
+++ b/src/ga/graph/scene.h
@@ -41,7 +41,7 @@ public:
 	bool hasNode( std::shared_ptr<Node> node );
 
 	std::shared_ptr<Node> getRootNode();
-	std::vector<std::shared_ptr<Node>> Scene::getNodes();
+	std::vector<std::shared_ptr<Node>> getNodes();
 	void forEachNode( std::function<void( std::shared_ptr<Node> )> fn );
 
 	void setName( const std::string& name );

--- a/src/ga/timeout.h
+++ b/src/ga/timeout.h
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include "Timer.h"
+#include "ga/timer.h"
 
 namespace ga {
 

--- a/src/ga/util.h
+++ b/src/ga/util.h
@@ -25,13 +25,13 @@ inline std::vector<std::string> splitString( const std::string& str, char delim 
 
 inline std::string toLower( std::string str )
 {
-	std::transform( str.begin(), str.end(), str.begin(), []( unsigned char c ) { return std::tolower( c, std::locale() ); } );
+	std::transform( str.begin(), str.end(), str.begin(), []( char c ) { return std::tolower( c, std::locale() ); } );
 	return str;
 }
 
 inline std::string toUpper( std::string str )
 {
-	std::transform( str.begin(), str.end(), str.begin(), []( unsigned char c ) { return std::toupper( c, std::locale() ); } );
+	std::transform( str.begin(), str.end(), str.begin(), []( char c ) { return std::toupper( c, std::locale() ); } );
 
 	return str;
 }


### PR DESCRIPTION
A few fixes for Xcode compilation errors:
- 9eaf9b5 - removed extra class qualifiers on Scene:: and Paragraph:: method declarations
- 0b89db5 - Timeout.h was including "Timer.h" instead of "ga/timer.h"
- 76db2d9 - fixed `ga::toLower()` and `ga::toUpper()` string conversion functions that were using `unsigned char` instead of `char` to step through strings

this should fix the ofxGAkit issue https://github.com/gallagher-tech/ofxGAkit/issues/4