### PR TITLE
use const nlohmann::json::at() not [] operator to avoid assert fail

### DIFF
--- a/src/ga/json.h
+++ b/src/ga/json.h
@@ -14,10 +14,10 @@ namespace json {
 		try {
 			if ( keyOrPointer.empty() || keyOrPointer.at( 0 ) == '/' ) {
 				// allow for json pointer paths - these are either empty or begin with '/'
-				ret = json[ga::Json::json_pointer( keyOrPointer )].get<T>();
+				ret = json.at(ga::Json::json_pointer( keyOrPointer )).get<T>();
 			} else {
 				// assume key is a normal key for a json object
-				ret = json[keyOrPointer].get<T>();
+				ret = json.at(keyOrPointer).get<T>();
 			}
 		} catch ( ... ) {
 			// todo: log warning? accept an ostream& for logging?

--- a/src/ga/json_types.h
+++ b/src/ga/json_types.h
@@ -80,7 +80,7 @@ inline void from_json( const ga::Json& j, ga::mat4& m )
 		// glm is column major - convert from row major
 		for ( int r = 0; r < 4; ++r ) {
 			for ( int c = 0; c < 4; ++c ) {
-				_m[c][r] = j[r][c];
+				_m[c][r] = j.at(r).at(c);
 			}
 		}
 	} catch ( std::exception& e ) {


### PR DESCRIPTION
const ga::Json requires using ga::Json::at() instead of [] operator to access elements

